### PR TITLE
Integrate with half baked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "WTFPL"
 publish = false
 
 [dependencies]
+byteorder = "1.3"
 clap = "2.33.3"
 solana-clap-utils = "=1.6.6"
 solana-cli-config = "=1.6.6"

--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ It provides three pieces of functionality:
       help       Prints this message or the help of the given subcommand(s)
       ping       Send a ping transaction
   ```
+
+### Debugging
+Use `export RUST_LOG=solana=debug`. `RUST_BACKTRACE=1` can also be useful.


### PR DESCRIPTION
- Updated the ping command to send a hard coded price to a deployed Half Baked instance.
- Added a new create-data-account command to create an account where Half Baked can store its state.